### PR TITLE
Removed fields not in use

### DIFF
--- a/Framework/Adxstudio.Xrm/AspNet/Cms/HealthMiddleware.cs
+++ b/Framework/Adxstudio.Xrm/AspNet/Cms/HealthMiddleware.cs
@@ -20,11 +20,6 @@ namespace Adxstudio.Xrm.AspNet.Cms
 	public class HealthMiddleware : OwinMiddleware
 	{
 		/// <summary>
-		/// info string
-		/// </summary>
-		private static string info;
-
-		/// <summary>
 		/// path string for health.
 		/// </summary>
 		private readonly PathString callbackPath = new PathString("/_services/about/health");

--- a/Framework/Adxstudio.Xrm/Diagnostics/Metrics/IfxMetricsReporter.cs
+++ b/Framework/Adxstudio.Xrm/Diagnostics/Metrics/IfxMetricsReporter.cs
@@ -110,7 +110,7 @@ namespace Adxstudio.Xrm.Diagnostics.Metrics
 		}
 
 #if CLOUDINSTRUMENTATION
-		readonly ConcurrentDictionary<IAdxMetric, MeasureMetric10D> _metricsCache = new ConcurrentDictionary<IAdxMetric, MeasureMetric10D>();		
+		readonly ConcurrentDictionary<IAdxMetric, MeasureMetric10D> _metricsCache = new ConcurrentDictionary<IAdxMetric, MeasureMetric10D>();
 		readonly string _mdmAccountName, _mdmNamespace, _geo, _tenant, _role, _roleInstance, _org, _portalType, _portalId, _portalApp, _portalUrl, _portalVersion;
 		readonly bool _initializationFailed;
 #endif

--- a/Framework/Adxstudio.Xrm/Diagnostics/Metrics/IfxMetricsReporter.cs
+++ b/Framework/Adxstudio.Xrm/Diagnostics/Metrics/IfxMetricsReporter.cs
@@ -110,8 +110,11 @@ namespace Adxstudio.Xrm.Diagnostics.Metrics
 		}
 
 #if CLOUDINSTRUMENTATION
-		readonly ConcurrentDictionary<IAdxMetric, MeasureMetric10D> _metricsCache = new ConcurrentDictionary<IAdxMetric, MeasureMetric10D>();
+		readonly ConcurrentDictionary<IAdxMetric, MeasureMetric10D> _metricsCache = new ConcurrentDictionary<IAdxMetric, MeasureMetric10D>();		
+		readonly string _mdmAccountName, _mdmNamespace, _geo, _tenant, _role, _roleInstance, _org, _portalType, _portalId, _portalApp, _portalUrl, _portalVersion;
+		readonly bool _initializationFailed;
 #endif
+
 		private IfxMetricsReporter()
 		{
 #if CLOUDINSTRUMENTATION

--- a/Framework/Adxstudio.Xrm/Diagnostics/Metrics/IfxMetricsReporter.cs
+++ b/Framework/Adxstudio.Xrm/Diagnostics/Metrics/IfxMetricsReporter.cs
@@ -112,9 +112,6 @@ namespace Adxstudio.Xrm.Diagnostics.Metrics
 #if CLOUDINSTRUMENTATION
 		readonly ConcurrentDictionary<IAdxMetric, MeasureMetric10D> _metricsCache = new ConcurrentDictionary<IAdxMetric, MeasureMetric10D>();
 #endif
-		readonly string _mdmAccountName, _mdmNamespace, _geo, _tenant, _role, _roleInstance, _org, _portalType, _portalId, _portalApp, _portalUrl, _portalVersion;
-		readonly bool _initializationFailed;
-
 		private IfxMetricsReporter()
 		{
 #if CLOUDINSTRUMENTATION


### PR DESCRIPTION
Removed fields that have been declared but were not used anywhere within
the solution to reduce build warnings/for clarity.