### PR TITLE
Fixed properties hiding inherited members

### DIFF
--- a/Framework/Adxstudio.Xrm/Activity/PortalComment.cs
+++ b/Framework/Adxstudio.Xrm/Activity/PortalComment.cs
@@ -29,7 +29,7 @@ namespace Adxstudio.Xrm.Activity
 		public PortalCommentDirectionCode DirectionCode { get; set; }
 		public Entity From { get; set; }
 		public Entity To { get; set; }
-		public IEnumerable<IAnnotationFile> FileAttachments { get; set; }
+		public new IEnumerable<IAnnotationFile> FileAttachments { get; set; }
 		public IAnnotationSettings AttachmentSettings { get; set; }
 		public Guid ActivityId { get; set; }
 	}

--- a/Framework/Adxstudio.Xrm/Marketing/DataAdapterDependencies.cs
+++ b/Framework/Adxstudio.Xrm/Marketing/DataAdapterDependencies.cs
@@ -27,8 +27,6 @@ namespace Adxstudio.Xrm.Marketing
 			PortalName = portalName;
 		}
 
-		protected string PortalName { get; private set; }
-
 		public override OrganizationServiceContext GetServiceContextForWrite()
 		{
 			return PortalCrmConfigurationManager.CreateServiceContext(PortalName);

--- a/Framework/Adxstudio.Xrm/Web/Providers/ContentMapEntityUrlProvider.cs
+++ b/Framework/Adxstudio.Xrm/Web/Providers/ContentMapEntityUrlProvider.cs
@@ -439,7 +439,7 @@ namespace Adxstudio.Xrm.Web.Providers
 			return null;
 		}
 
-		private static ApplicationPath JoinApplicationPath(string basePath, string extendedPath)
+		private new ApplicationPath JoinApplicationPath(string basePath, string extendedPath)
 		{
 			if (string.IsNullOrWhiteSpace(basePath) || basePath.Contains("?") || basePath.Contains(":") || basePath.Contains("//") || basePath.Contains("&")
 				|| basePath.Contains("%3f") || basePath.Contains("%2f%2f") || basePath.Contains("%26"))


### PR DESCRIPTION
2 properties were intended to hide, applied 'new'. One was not required
so removed.

Reduced noise from warnings on build.

Refers to issue #12.