### PR TITLE
Remove Microsoft.ServiceBus reference in Microsoft.Xrm.Portal project

### DIFF
--- a/Framework/Microsoft.Xrm.Portal/Microsoft.Xrm.Portal.csproj
+++ b/Framework/Microsoft.Xrm.Portal/Microsoft.Xrm.Portal.csproj
@@ -66,9 +66,6 @@
       <HintPath>..\..\packages\Microsoft.IdentityModel.6.1.7600.16394\lib\net35\Microsoft.IdentityModel.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.ServiceBus">
-      <HintPath>..\..\DllImports\Microsoft.ServiceBus.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Xrm.Sdk">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0.2\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
There are no compilation errors when removing the reference. Any unforseen code in the project that may need the Microsoft.ServiceBus assembly should still have access to it by other projects that reference it and cause it to be copied to MasterPortal\bin.