### PR TITLE
Issue 6 Switched the default security protols to use TLS1.2 or TLS 1.1

### DIFF
--- a/Samples/MasterPortal/Global.asax.cs
+++ b/Samples/MasterPortal/Global.asax.cs
@@ -26,14 +26,16 @@ namespace Site
 	using Adxstudio.Xrm.Web.Mvc;
 	using Microsoft.Xrm.Portal.Configuration;
 	using Adxstudio.Xrm.AspNet.Cms;
+    using System.Net;
 
-	public class Global : HttpApplication
+    public class Global : HttpApplication
 	{
 		private static bool _setupRunning;
 
 		void Application_Start(object sender, EventArgs e)
 		{
-			AntiForgeryConfig.CookieName = "__RequestVerificationToken"; // static name as its dependent on the ajax handler.
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
+            AntiForgeryConfig.CookieName = "__RequestVerificationToken"; // static name as its dependent on the ajax handler.
 			MvcHandler.DisableMvcResponseHeader = true;
 			_setupRunning = SetupConfig.ApplicationStart();
 


### PR DESCRIPTION
Fixes current issue 6 https://github.com/Adoxio/dynamics-portal-companion-app/issues/6

Changing the default security protocol to include TLS 1.2, which is now required to connect to Dynamics 365 Online as per https://blogs.msdn.microsoft.com/crm/2017/09/28/updates-coming-to-dynamics-365-customer-engagement-connection-security/