### PR TITLE
Implemented column override for EntityListViewColumns liquid objects …

### DIFF
--- a/Framework/Adxstudio.Xrm/Web/Mvc/Liquid/EntityListViewColumnDrop.cs
+++ b/Framework/Adxstudio.Xrm/Web/Mvc/Liquid/EntityListViewColumnDrop.cs
@@ -10,13 +10,34 @@ namespace Adxstudio.Xrm.Web.Mvc.Liquid
 {
 	public class EntityListViewColumnDrop : PortalDrop
 	{
-		public EntityListViewColumnDrop(IPortalLiquidContext portalLiquidContext, SavedQueryView.ViewColumn column)
+		public EntityListViewColumnDrop(IPortalLiquidContext portalLiquidContext, SavedQueryView.ViewColumn column, List<UI.JsonConfiguration.ViewColumn> overridenColumns = null)
 			: base(portalLiquidContext)
 		{
 			if (column == null) throw new ArgumentNullException("column");
 
-			Column = column;
+			if(overridenColumns == null || overridenColumns?.Count == 0)
+			{
+				Column = column;
+			}
+			else
+			{
+				var o = overridenColumns.FirstOrDefault(c =>
+					c.AttributeLogicalName == column.LogicalName);
+				if (o != null)
+				{
+					column.Name = o.DisplayName;
 
+					if (o.Width != 0)
+					{
+						column.Width = o.Width;
+					}
+				}
+				else
+				{
+					Column = column;
+				}
+			}
+			
 			SortAscending = Column.LogicalName + " ASC";
 			SortDescending = Column.LogicalName + " DESC";
 		}


### PR DESCRIPTION
…based on Entitylist configuration

When creating a custom web template to render an EntityList, configuration to override columns name and width is not implemented.

This PR adds the required code so that this configuration is honored when rendering an Entitylist using DotLiquid